### PR TITLE
Pass correct project ID to get tenant_usages

### DIFF
--- a/openstack_dashboard/dashboards/identity/projects/tests.py
+++ b/openstack_dashboard/dashboards/identity/projects/tests.py
@@ -216,7 +216,7 @@ class CreateProjectWorkflowTests(test.BaseAdminViewTests):
                             ['<CreateProjectInfo: createprojectinfoaction>',
                              '<UpdateProjectMembers: update_members>',
                              '<UpdateProjectGroups: update_group_members>',
-                             '<UpdateProjectQuota: update_quotas>'])
+                             '<CreateProjectQuota: create_quotas>'])
 
     def test_add_project_get_domain(self):
         domain = self.domains.get(id="1")
@@ -304,7 +304,6 @@ class CreateProjectWorkflowTests(test.BaseAdminViewTests):
         users = self._get_all_users(domain_id)
         groups = self._get_all_groups(domain_id)
         roles = self.roles.list()
-        quota_usages = self.quota_usages.first()
 
         # init
         quotas.get_disabled_quotas(IsA(http.HttpRequest)) \
@@ -324,8 +323,6 @@ class CreateProjectWorkflowTests(test.BaseAdminViewTests):
             .AndReturn(groups)
 
         # handle
-        quotas.tenant_quota_usages(IsA(http.HttpRequest)) \
-                .AndReturn(quota_usages)
         project_details = self._get_project_info(project)
         quota_data = self._get_quota_info(quota)
 
@@ -458,7 +455,6 @@ class CreateProjectWorkflowTests(test.BaseAdminViewTests):
         users = self._get_all_users(domain_id)
         groups = self._get_all_groups(domain_id)
         roles = self.roles.list()
-        quota_usages = self.quota_usages.first()
 
         # init
         api.keystone.get_default_domain(IsA(http.HttpRequest)) \
@@ -477,8 +473,6 @@ class CreateProjectWorkflowTests(test.BaseAdminViewTests):
             .AndReturn(groups)
 
         # handle
-        quotas.tenant_quota_usages(IsA(http.HttpRequest)) \
-                .AndReturn(quota_usages)
         project_details = self._get_project_info(project)
 
         api.keystone.tenant_create(IsA(http.HttpRequest), **project_details) \
@@ -500,57 +494,6 @@ class CreateProjectWorkflowTests(test.BaseAdminViewTests):
                               domain_context_name=domain.name)
         self.test_add_project_tenant_create_error()
 
-    @test.create_stubs({api.keystone: ('user_list',
-                                       'role_list',
-                                       'group_list',
-                                       'get_default_domain',
-                                       'get_default_role',
-                                       'add_tenant_user_role'),
-                        quotas: ('get_default_quota_data',
-                                 'get_disabled_quotas',
-                                 'tenant_quota_usages'),
-                        api.nova: ('tenant_quota_update',)})
-    def test_project_quota_update_invalid_value(self):
-        project = self.tenants.first()
-        quota = self.quotas.first()
-        default_role = self.roles.first()
-        default_domain = self._get_default_domain()
-        domain_id = default_domain.id
-        users = self._get_all_users(domain_id)
-        groups = self._get_all_groups(domain_id)
-        roles = self.roles.list()
-        quota_usages = self.quota_usages.first()
-        quota_usages['instances']['used'] = 5
-
-        # init
-        api.keystone.get_default_domain(IsA(http.HttpRequest)) \
-            .AndReturn(default_domain)
-        quotas.get_disabled_quotas(IsA(http.HttpRequest)) \
-            .AndReturn(self.disabled_quotas.first())
-        quotas.get_default_quota_data(IsA(http.HttpRequest)).AndReturn(quota)
-
-        api.keystone.get_default_role(IsA(http.HttpRequest)) \
-            .MultipleTimes().AndReturn(default_role)
-        api.keystone.user_list(IsA(http.HttpRequest), domain=domain_id) \
-            .AndReturn(users)
-        api.keystone.role_list(IsA(http.HttpRequest)) \
-            .MultipleTimes().AndReturn(roles)
-        api.keystone.group_list(IsA(http.HttpRequest), domain=domain_id) \
-            .AndReturn(groups)
-        quotas.tenant_quota_usages(IsA(http.HttpRequest)) \
-                .AndReturn(quota_usages)
-
-        self.mox.ReplayAll()
-
-        workflow_data = {}
-        workflow_data.update(self._get_workflow_data(project, quota))
-        workflow_data['instances'] = 2
-        url = reverse('horizon:identity:projects:create')
-        res = self.client.post(url, workflow_data)
-        msg = 'Quota value(s) cannot be less than the current usage ' \
-              'value(s): 5 Instances used.'
-        self.assertContains(res, msg)
-
     @test.create_stubs({api.keystone: ('tenant_create',
                                        'user_list',
                                        'role_list',
@@ -571,7 +514,6 @@ class CreateProjectWorkflowTests(test.BaseAdminViewTests):
         users = self._get_all_users(domain_id)
         groups = self._get_all_groups(domain_id)
         roles = self.roles.list()
-        quota_usages = self.quota_usages.first()
 
         # init
         api.keystone.get_default_domain(IsA(http.HttpRequest)) \
@@ -590,8 +532,6 @@ class CreateProjectWorkflowTests(test.BaseAdminViewTests):
             .AndReturn(groups)
 
         # handle
-        quotas.tenant_quota_usages(IsA(http.HttpRequest)) \
-                .AndReturn(quota_usages)
         project_details = self._get_project_info(project)
         quota_data = self._get_quota_info(quota)
 
@@ -660,7 +600,6 @@ class CreateProjectWorkflowTests(test.BaseAdminViewTests):
         users = self._get_all_users(domain_id)
         groups = self._get_all_groups(domain_id)
         roles = self.roles.list()
-        quota_usages = self.quota_usages.first()
 
         # init
         api.keystone.get_default_domain(IsA(http.HttpRequest)) \
@@ -679,8 +618,6 @@ class CreateProjectWorkflowTests(test.BaseAdminViewTests):
             .AndReturn(groups)
 
         # handle
-        quotas.tenant_quota_usages(IsA(http.HttpRequest)) \
-                .AndReturn(quota_usages)
         project_details = self._get_project_info(project)
         quota_data = self._get_quota_info(quota)
 
@@ -745,7 +682,6 @@ class CreateProjectWorkflowTests(test.BaseAdminViewTests):
         users = self._get_all_users(domain_id)
         groups = self._get_all_groups(domain_id)
         roles = self.roles.list()
-        quota_usages = self.quota_usages.first()
 
         # init
         api.keystone.get_default_domain(IsA(http.HttpRequest)) \
@@ -762,9 +698,6 @@ class CreateProjectWorkflowTests(test.BaseAdminViewTests):
             .MultipleTimes().AndReturn(roles)
         api.keystone.group_list(IsA(http.HttpRequest), domain=domain_id) \
             .AndReturn(groups)
-
-        quotas.tenant_quota_usages(IsA(http.HttpRequest)) \
-                .AndReturn(quota_usages)
 
         self.mox.ReplayAll()
 
@@ -1103,7 +1036,7 @@ class UpdateProjectWorkflowTests(test.BaseAdminViewTests):
                                     group='3',
                                     project=self.tenant.id)
 
-        quotas.tenant_quota_usages(IsA(http.HttpRequest)) \
+        quotas.tenant_quota_usages(IsA(http.HttpRequest), tenant_id=project.id) \
                 .AndReturn(quota_usages)
 
         nova_updated_quota = dict([(key, updated_quota[key]) for key in
@@ -1266,7 +1199,7 @@ class UpdateProjectWorkflowTests(test.BaseAdminViewTests):
         updated_quota = self._get_quota_info(quota)
 
         # handle
-        quotas.tenant_quota_usages(IsA(http.HttpRequest)) \
+        quotas.tenant_quota_usages(IsA(http.HttpRequest), tenant_id=project.id) \
                 .AndReturn(quota_usages)
         api.keystone.tenant_update(IsA(http.HttpRequest),
                                    project.id,
@@ -1442,7 +1375,7 @@ class UpdateProjectWorkflowTests(test.BaseAdminViewTests):
                                     group='3',
                                     project=self.tenant.id)
 
-        quotas.tenant_quota_usages(IsA(http.HttpRequest)) \
+        quotas.tenant_quota_usages(IsA(http.HttpRequest), tenant_id=project.id) \
                 .AndReturn(quota_usages)
 
         nova_updated_quota = dict([(key, updated_quota[key]) for key in
@@ -1562,7 +1495,7 @@ class UpdateProjectWorkflowTests(test.BaseAdminViewTests):
         updated_quota = self._get_quota_info(quota)
 
         # handle
-        quotas.tenant_quota_usages(IsA(http.HttpRequest)) \
+        quotas.tenant_quota_usages(IsA(http.HttpRequest), tenant_id=project.id) \
                 .AndReturn(quota_usages)
         api.keystone.tenant_update(IsA(http.HttpRequest),
                                    project.id,

--- a/openstack_dashboard/dashboards/identity/projects/views.py
+++ b/openstack_dashboard/dashboards/identity/projects/views.py
@@ -150,14 +150,14 @@ class CreateProjectView(workflows.WorkflowView):
             except Exception:
                 error_msg = _('Unable to retrieve default Neutron quota '
                               'values.')
-                self.add_error_to_step(error_msg, 'update_quotas')
+                self.add_error_to_step(error_msg, 'create_quotas')
 
             for field in quotas.QUOTA_FIELDS:
                 initial[field] = quota_defaults.get(field).limit
 
         except Exception:
             error_msg = _('Unable to retrieve default quota values.')
-            self.add_error_to_step(error_msg, 'update_quotas')
+            self.add_error_to_step(error_msg, 'create_quotas')
 
         return initial
 


### PR DESCRIPTION
The current implementation of tenant_quota_usages did not allow for
queries regarding projects that were not the currently active project,
this meant that when an admin went to edit or create a project it tried
to verify the usages against the wrong project. This patch adds the
code for passing a project id to the tenant_quota_usages function so
that the usages can be fetched for a specific project, as well as
removes the need for usage validation on creation of a new project.

(cherry picked from commit 193d40a41472adc6c27e18256524afb2dacb9156)

Change-Id: I3ec84d14c8be7e3aae066119e963c4093f8aa345
Closes-Bug: 1380701
