### PR TITLE
LBaas v1 Associate Monitor to Pool Fails

### DIFF
--- a/openstack_dashboard/api/lbaas.py
+++ b/openstack_dashboard/api/lbaas.py
@@ -187,8 +187,11 @@ def _pool_get(request, pool_id, expand_resource=False):
                                expand_name_only=False)
         pool['members'] = _member_list(request, expand_pool=False,
                                        pool_id=pool_id)
-        pool['health_monitors'] = pool_health_monitor_list(
-            request, id=pool['health_monitors'])
+        monitors = []
+        for monitor_id in pool['health_monitors']:
+            monitors.append(_pool_health_monitor_get(request, monitor_id,
+                                                     False))
+        pool['health_monitors'] = monitors
     return Pool(pool)
 
 


### PR DESCRIPTION
The associate monitor fails to show monitors to choose from
within horizon.  The monitor list code has changed where
you can no longer list monitors with a filter criteria.
This change switches to grab needed monitors one at a time.

Fixes: redmine #3719

Change-Id: Ibc5233028507c66de459e84e91f65c9557940ea5
Closes-bug: #1398754
(cherry picked from commit 0dde489a81ea8599e75d45ac0be34048a5c366d0)
Signed-off-by: huntxu mhuntxu@gmail.com

Conflicts:
    openstack_dashboard/api/lbaas.py
